### PR TITLE
📝 修改README已经404的链接

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -89,7 +89,7 @@ We welcome PRs! Check [CONTRIBUTING.md](https://project-graph.top/docs/contribut
 
 <!----------------------------------------------------------------------------->
 
-[Install]: https://project-graph.top/installation
+[Install]: https://project-graph.top/docs/app
 [Website]: https://project-graph.top
 [Online Demo]: https://web.project-graph.top
 [Weblate]: https://hosted.weblate.org/engage/project-graph/


### PR DESCRIPTION
README的「install按钮」链接跳过去是404，修改成「快速开始」页面