### PR TITLE
feat: 粘贴/拖入图片时自动包裹分组框

### DIFF
--- a/app/src/core/service/Settings.tsx
+++ b/app/src/core/service/Settings.tsx
@@ -170,6 +170,7 @@ export const settingsSchema = z.object({
   webpQuality: z.number().min(0.01).max(1).default(0.85),
   compressImageToBlackAndWhite: z.boolean().default(false),
   blackAndWhiteThreshold: z.number().min(0).max(1).default(0.5),
+  wrapImageInGroup: z.boolean().default(false),
   textNodeManualDefaultCharWidth: z.number().int().min(3).max(60).default(10),
   allowAddCycleEdge: z.boolean().default(false),
   enableDragNodeShakeDetachFromEdge: z.boolean().default(false),

--- a/app/src/core/service/SettingsIcons.tsx
+++ b/app/src/core/service/SettingsIcons.tsx
@@ -176,6 +176,7 @@ export const settingsIcons = {
   webpQuality: Percent,
   compressImageToBlackAndWhite: Contrast,
   blackAndWhiteThreshold: Gauge,
+  wrapImageInGroup: SquareDashed,
   maxPastedImageSize: ImageUpscale,
   autoRefreshStageByMouseAction: RefreshCcwDot,
   isPauseRenderWhenManipulateOvertime: Hourglass,

--- a/app/src/core/service/dataManageService/copyEngine/copyEngineImage.tsx
+++ b/app/src/core/service/dataManageService/copyEngine/copyEngineImage.tsx
@@ -8,6 +8,7 @@ import { MouseLocation } from "../../controlService/MouseLocation";
 import { Settings } from "@/core/service/Settings";
 import { applyBlackAndWhite } from "../imageUtils";
 import { toast } from "sonner";
+import { Section } from "@/core/stage/stageObject/entity/Section";
 
 export class CopyEngineImage {
   constructor(private project: Project) {}
@@ -90,10 +91,21 @@ export class CopyEngineImage {
     const attachmentId = this.project.addAttachment(blob);
     const location = this.project.renderer.transformView2World(MouseLocation.vector());
 
-    const imageNode = new ImageNode(this.project, {
-      attachmentId,
-      collisionBox: new CollisionBox([new Rectangle(location, new Vector(300, 150))]),
-    });
+    const imageNode = new ImageNode(
+      this.project,
+      {
+        attachmentId,
+        collisionBox: new CollisionBox([new Rectangle(location, new Vector(300, 150))]),
+      },
+      false,
+      Settings.wrapImageInGroup
+        ? () => {
+            const section = Section.fromEntities(this.project, [imageNode]);
+            section.text = "";
+            this.project.stageManager.add(section);
+          }
+        : undefined,
+    );
 
     this.project.stageManager.add(imageNode);
   }

--- a/app/src/core/service/dataManageService/dragFileIntoStageEngine/dragFileIntoStageEngine.tsx
+++ b/app/src/core/service/dataManageService/dragFileIntoStageEngine/dragFileIntoStageEngine.tsx
@@ -13,6 +13,7 @@ import { PathString } from "@/utils/pathString";
 import { DetailsManager } from "@/core/stage/stageObject/tools/entityDetailsManager";
 import { Settings } from "@/core/service/Settings";
 import { applyBlackAndWhite } from "../imageUtils";
+import { Section } from "@/core/stage/stageObject/entity/Section";
 
 /**
  * 处理文件拖拽到舞台的引擎
@@ -248,10 +249,21 @@ export namespace DragFileIntoStageEngine {
     addLocation.x += -imageIndex * 50;
     addLocation.y += imageIndex * 50;
 
-    const imageNode = new ImageNode(project, {
-      attachmentId,
-      collisionBox: new CollisionBox([new Rectangle(addLocation, new Vector(1, 1))]),
-    });
+    const imageNode = new ImageNode(
+      project,
+      {
+        attachmentId,
+        collisionBox: new CollisionBox([new Rectangle(addLocation, new Vector(1, 1))]),
+      },
+      false,
+      Settings.wrapImageInGroup
+        ? () => {
+            const section = Section.fromEntities(project, [imageNode]);
+            section.text = "";
+            project.stageManager.add(section);
+          }
+        : undefined,
+    );
 
     project.stageManager.add(imageNode);
   }

--- a/app/src/core/stage/stageObject/entity/ImageNode.tsx
+++ b/app/src/core/stage/stageObject/entity/ImageNode.tsx
@@ -71,6 +71,7 @@ export class ImageNode extends ConnectableEntity implements ResizeAble {
       isBackground = false,
     },
     public unknown = false,
+    public onReady?: () => void,
   ) {
     super();
     this.uuid = uuid;
@@ -90,6 +91,7 @@ export class ImageNode extends ConnectableEntity implements ResizeAble {
       this.state = "success";
       // 设置碰撞箱
       this.scaleUpdate(0);
+      this.onReady?.();
     });
   }
 

--- a/app/src/locales/en.yml
+++ b/app/src/locales/en.yml
@@ -881,6 +881,10 @@ settings:
   blackAndWhiteThreshold:
     title: Black & White Threshold
     description: "0 is full grayscale, 1 is pure black and white (only black and pure white colors).\nOnly takes effect when \"Black & White Compression\" is enabled.\n"
+  wrapImageInGroup:
+    title: Auto-wrap Pasted/Dropped Images in Section
+    description: |
+      When enabled, images pasted from the clipboard or dragged from outside will be automatically wrapped in a section frame.
   maxPastedImageSize:
     description: "For images whose width or height exceeds this size, their maximum
       width or height is limited to this size.\nMeanwhile, it keeps the aspect ratio,

--- a/app/src/locales/id.yml
+++ b/app/src/locales/id.yml
@@ -437,6 +437,10 @@ settings:
     description: |
       0 adalah skala abu-abu penuh, 1 adalah hitam putih murni (hanya warna hitam dan putih).
       Hanya berlaku saat "Kompres Hitam Putih" diaktifkan
+  wrapImageInGroup:
+    title: Bungkus Gambar yang Ditempel/Diseret ke dalam Seksi
+    description: |
+      Saat diaktifkan, gambar yang ditempel dari clipboard atau diseret dari luar akan otomatis dibungkus dalam bingkai seksi.
   maxPastedImageSize:
     title: Batas Ukuran Gambar yang Ditempel (piksel)
     description: |

--- a/app/src/locales/zh_CN.yml
+++ b/app/src/locales/zh_CN.yml
@@ -454,6 +454,10 @@ settings:
     description: |
       0 为完整灰度，1 为纯黑白（仅黑和纯白两种颜色）。
       仅在开启「黑白压缩」时生效
+  wrapImageInGroup:
+    title: 粘贴/拖入图片时自动套框
+    description: |
+      开启后，从剪贴板粘贴或从外部拖入的图片将被自动包裹在一个分组框（Section）中。
   maxPastedImageSize:
     title: 粘贴到舞台的图片的尺寸限制（像素）
     description: |

--- a/app/src/locales/zh_TW.yml
+++ b/app/src/locales/zh_TW.yml
@@ -454,6 +454,10 @@ settings:
     description: |
       0 為完整灰度，1 為純黑白（僅黑和純白兩種顏色）。
       僅在開啟「黑白壓縮」時生效
+  wrapImageInGroup:
+    title: 粘貼/拖入圖片時自動套框
+    description: |
+      開啟後，從剪貼板粘貼或從外部拖入的圖片將被自動包裹在一個分組框（Section）中。
   maxPastedImageSize:
     title: 粘貼到舞臺的圖片的尺寸限制（像素）
     description: |

--- a/app/src/locales/zh_TWC.yml
+++ b/app/src/locales/zh_TWC.yml
@@ -468,6 +468,9 @@ settings:
   blackAndWhiteThreshold:
     title: 黑白閾值
     description: '0 為完整灰度，1 為純黑白（只有黑和純白兩種顏色）。僅在開啟「黑白壓縮」時生效'
+  wrapImageInGroup:
+    title: 貼上/拖入圖片時自動加上外框
+    description: '開啟後，從剪貼簿貼上或從外部拖入的圖片將被自動包裹在一個分組框（Section）中。'
   maxPastedImageSize:
     title: 貼上到舞台的圖片的尺寸限制（像素）
     description: '長或寬超過此尺寸的圖片，其長或寬的最大值將會被限制為此大小

--- a/app/src/sub/SettingsWindow/settings.tsx
+++ b/app/src/sub/SettingsWindow/settings.tsx
@@ -350,6 +350,7 @@ export const categories = {
       "webpQuality",
       "compressImageToBlackAndWhite",
       "blackAndWhiteThreshold",
+      "wrapImageInGroup",
       "clipboardPasteMode",
     ],
   },


### PR DESCRIPTION
@
## Summary

在粘贴或拖入图片时，自动为图片创建一个分组框（Section），将其包裹在内。提供开关在设置中控制该行为。

## Changes

### 🌟 新功能
- **新设置项 `wrapImageInGroup`**（默认关闭）：开启后，从剪贴板粘贴或从外部拖入的图片将被自动包裹在一个分组框（Section）中

### 🐛 Bug 修复
- **修复首次加载时分组框尺寸不正确的问题**：图片通过 `createImageBitmap` 异步加载，而 `Section.fromEntities` 依赖实体碰撞箱的准确尺寸。新增 `onReady` 回调，确保在 bitmap 加载完毕后才创建分组框，避免框被初始化为默认小尺寸

### 📁 文件变更（11 个文件，+56 / -8）
| 文件 | 变更 |
|------|------|
| `Settings.tsx` | 添加 `wrapImageInGroup: z.boolean().default(false)` |
| `SettingsIcons.tsx` | 添加 `wrapImageInGroup: SquareDashed` 图标 |
| `settings.tsx` | 在设置 UI「图片」分类添加开关 |
| `ImageNode.tsx` | 添加 `onReady` 回调参数，在 bitmap 加载后调用 |
| `copyEngineImage.tsx` | 粘贴时按设置自动套框（onReady 回调内） |
| `dragFileIntoStageEngine.tsx` | 拖入时按设置自动套框（onReady 回调内） |
| 5 个 locale 文件 | 添加多语言翻译 |
@