### PR TITLE
feat: AI 图片识别 + 答案落盘 TextNode

### DIFF
--- a/app/src/core/service/dataManageService/aiEngine/AITools.tsx
+++ b/app/src/core/service/dataManageService/aiEngine/AITools.tsx
@@ -5,8 +5,15 @@ import { Edge } from "@/core/stage/stageObject/association/Edge";
 import { Color, Vector } from "@graphif/data-structures";
 import { serialize } from "@graphif/serializer";
 import { Rectangle } from "@graphif/shapes";
-import { tool, type ToolSet } from "ai";
+import { generateText, tool, type ToolSet } from "ai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { fetch } from "@tauri-apps/plugin-http";
 import z from "zod/v4";
+import { Settings } from "@/core/service/Settings";
+import { blobToCompressedDataUrl } from "@/core/service/dataManageService/imageUtils";
+import { ImageNode } from "@/core/stage/stageObject/entity/ImageNode";
+import { Section } from "@/core/stage/stageObject/entity/Section";
+import { findFirstImageInChildren } from "./imageNodeFinder";
 
 export namespace AITools {
   export type ToolDefinition = {
@@ -17,6 +24,7 @@ export namespace AITools {
 
   type InternalToolDefinition = ToolDefinition & {
     fn: (project: Project, data: any) => any;
+    toModelOutput?: (output: any) => { type: "content"; value: any[] };
   };
 
   const toolDefinitions: InternalToolDefinition[] = [];
@@ -27,8 +35,15 @@ export namespace AITools {
     description: string,
     parameters: A,
     fn: (project: Project, data: z.infer<A>) => any,
+    toModelOutput?: (output: any) => { type: "content"; value: any[] },
   ) {
-    toolDefinitions.push({ name, description, parameters, fn: fn as (project: Project, data: any) => any });
+    toolDefinitions.push({
+      name,
+      description,
+      parameters,
+      fn: fn as (project: Project, data: any) => any,
+      toModelOutput,
+    });
   }
 
   export function createTools(project: Project): ToolSet {
@@ -42,6 +57,11 @@ export namespace AITools {
             const result = await definition.fn(project, data as any);
             return result ?? { success: true };
           },
+          ...(definition.toModelOutput
+            ? {
+                toModelOutput: ({ output }: { output: any }) => definition.toModelOutput!(output),
+              }
+            : {}),
         }),
       ]),
     ) as ToolSet;
@@ -761,4 +781,72 @@ export namespace AITools {
       return { success: true, movedCount: desired_order.length };
     },
   );
+  addTool(
+    "recognize_image_by_uuid",
+    "识别指定节点中的图片内容并返回文字描述。传入 ImageNode 的 uuid（或包含图片的 Section 的 uuid，会自动取其内部第一张图片），并用 prompt 描述你想识别什么。工具会用多模态模型独立识别图片（不依赖主对话上下文），返回识别结果的文字描述。",
+    z.object({
+      uuid: z.string().describe("ImageNode 的 uuid，或包含图片的 Section 的 uuid"),
+      prompt: z
+        .string()
+        .describe('向图像识别模型提问的提示词，例如"这张图片里有哪些文字？"或"描述图片中的主要物体和场景"。'),
+    }),
+    async (project, { uuid, prompt }) => {
+      const obj = project.stageManager.get(uuid);
+      if (!obj) {
+        return { success: false, error: "未找到该 uuid 对应的节点" };
+      }
+      const imageNode = (
+        obj instanceof ImageNode
+          ? obj
+          : findFirstImageInChildren(
+              obj instanceof Section ? obj.children : [],
+              (n) => n instanceof ImageNode,
+              (n) => (n instanceof Section ? n.children : undefined),
+            )
+      ) as ImageNode | undefined;
+      if (!imageNode) {
+        return { success: false, error: "该节点不是 ImageNode，且其内部未找到图片" };
+      }
+      const blob = project.attachments.get(imageNode.attachmentId);
+      if (!blob) {
+        return { success: false, error: "图片数据未找到（附件可能已丢失）" };
+      }
+      try {
+        const dataUrl = await blobToCompressedDataUrl(blob, Settings.maxPastedImageSize);
+        const description = await recognizeImage(dataUrl, prompt);
+        return { success: true, description };
+      } catch (e) {
+        return { success: false, error: e instanceof Error ? e.message : "图片识别失败" };
+      }
+    },
+  );
+}
+
+async function recognizeImage(dataUrl: string, prompt: string): Promise<string> {
+  const provider = createOpenAICompatible({
+    name: "project-graph",
+    baseURL: Settings.aiApiBaseUrl,
+    apiKey: Settings.aiApiKey || undefined,
+    fetch: async (url: any, init: any) => {
+      const response = await fetch(url.toString(), { ...init, mode: "cors" });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "unknown error");
+        throw new Error(`图像识别请求失败 (${response.status}): ${errorText}`);
+      }
+      return response;
+    },
+  });
+  const result = await generateText({
+    model: provider.chatModel(Settings.aiModel),
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: prompt },
+          { type: "image", image: dataUrl },
+        ],
+      },
+    ],
+  });
+  return result.text;
 }

--- a/app/src/core/service/dataManageService/aiEngine/imageNodeFinder.test.ts
+++ b/app/src/core/service/dataManageService/aiEngine/imageNodeFinder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { findFirstImageInChildren } from "./imageNodeFinder";
+
+describe("findFirstImageInChildren", () => {
+  it("命中第一个 image 节点时直接返回", () => {
+    const img = { kind: "image" };
+    const text = { kind: "text" };
+    const result = findFirstImageInChildren(
+      [text, img],
+      (n) => n.kind === "image",
+      () => undefined,
+    );
+    expect(result).toBe(img);
+  });
+
+  it("递归进入容器节点的 children 找到 image", () => {
+    const img = { kind: "image" };
+    const section = { kind: "section", children: [{ kind: "text" }, img] };
+    const result = findFirstImageInChildren(
+      [section],
+      (n: any) => n.kind === "image",
+      (n: any) => (n.kind === "section" ? n.children : undefined),
+    );
+    expect(result).toBe(img);
+  });
+
+  it("多层嵌套时找到最深的 image", () => {
+    const img = { kind: "image" };
+    const inner = { kind: "section", children: [img] };
+    const outer = { kind: "section", children: [inner] };
+    const result = findFirstImageInChildren(
+      [outer],
+      (n: any) => n.kind === "image",
+      (n: any) => (n.kind === "section" ? n.children : undefined),
+    );
+    expect(result).toBe(img);
+  });
+
+  it("没有任何 image 时返回 undefined", () => {
+    const result = findFirstImageInChildren(
+      [{ kind: "text" }, { kind: "section", children: [{ kind: "text" }] }],
+      (n: any) => n.kind === "image",
+      (n: any) => (n.kind === "section" ? n.children : undefined),
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/src/core/service/dataManageService/aiEngine/imageNodeFinder.ts
+++ b/app/src/core/service/dataManageService/aiEngine/imageNodeFinder.ts
@@ -1,0 +1,15 @@
+export function findFirstImageInChildren<T>(
+  children: T[],
+  isImage: (node: T) => boolean,
+  getChildren: (node: T) => T[] | undefined,
+): T | undefined {
+  for (const child of children) {
+    if (isImage(child)) return child;
+    const sub = getChildren(child);
+    if (sub) {
+      const found = findFirstImageInChildren(sub, isImage, getChildren);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}

--- a/app/src/core/service/dataManageService/imageUtils.tsx
+++ b/app/src/core/service/dataManageService/imageUtils.tsx
@@ -26,3 +26,41 @@ export function applyBlackAndWhite(canvas: HTMLCanvasElement): void {
 
   ctx.putImageData(imageData, 0, 0);
 }
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("图片加载失败"));
+    img.src = src;
+  });
+}
+
+export async function blobToCompressedDataUrl(blob: Blob, maxSize: number): Promise<string> {
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = await loadImage(url);
+    let width = img.naturalWidth;
+    let height = img.naturalHeight;
+    if (width === 0 || height === 0) {
+      throw new Error("图片尺寸无效（可能为无内禀尺寸的 SVG）");
+    }
+    const maxDim = Math.max(width, height);
+    if (maxDim > maxSize) {
+      const scale = maxSize / maxDim;
+      width = Math.round(width * scale);
+      height = Math.round(height * scale);
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      throw new Error("无法获取 canvas 2d 上下文");
+    }
+    ctx.drawImage(img, 0, 0, width, height);
+    return canvas.toDataURL("image/png");
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/app/src/sub/AIWindow.tsx
+++ b/app/src/sub/AIWindow.tsx
@@ -14,7 +14,11 @@ import { Rectangle } from "@graphif/shapes";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@radix-ui/react-collapsible";
 import type { UIMessage } from "ai";
 import { useAtom } from "jotai";
-import { Bot, Check, ChevronRight, FolderOpen, Paperclip, Send, Sparkles, Square, User, X } from "lucide-react";
+import { Bot, Check, ChevronRight, FolderOpen, Paperclip, Plus, Send, Sparkles, Square, User, X } from "lucide-react";
+import { CollisionBox } from "@/core/stage/stageObject/collisionBox/collisionBox";
+import { ConnectableEntity } from "@/core/stage/stageObject/abstract/ConnectableEntity";
+import { Section } from "@/core/stage/stageObject/entity/Section";
+import { TextNode } from "@/core/stage/stageObject/entity/TextNode";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getOriginalNameOf } from "virtual:original-class-name";
@@ -57,6 +61,40 @@ function isEntity(
   obj: unknown,
 ): obj is { isSelected: boolean; collisionBox: { getRectangle(): Rectangle }; color?: Color } {
   return typeof obj === "object" && obj !== null && "isSelected" in obj && "collisionBox" in obj;
+}
+
+function createAnswerNode(message: UIMessage, project: Project) {
+  const answerText = (Array.isArray(message.parts) ? message.parts : [])
+    .filter((p: any) => p.type === "text")
+    .map((p: any) => p.text ?? "")
+    .join("\n")
+    .trim();
+  if (!answerText) {
+    toast.error("该消息没有可落盘的文本");
+    return;
+  }
+  const selected = project.stageManager.getSelectedEntities();
+  const source = selected.find((e) => e instanceof Section) ?? selected.find((e) => e instanceof ConnectableEntity);
+  if (!source) {
+    toast.error("请先选中要指向的分组框或节点");
+    return;
+  }
+  const sourceRect = source.collisionBox.getRectangle();
+  const node = new TextNode(project, {
+    text: answerText,
+    color: new Color(0, 0, 0, 0),
+    collisionBox: new CollisionBox([
+      new Rectangle(
+        new Vector(sourceRect.location.x + sourceRect.size.x + 100, sourceRect.location.y),
+        new Vector(100, 50),
+      ),
+    ]),
+    sizeAdjust: "auto",
+  });
+  project.stageManager.add(node);
+  project.nodeConnector.connectConnectableEntity(source, node);
+  project.historyManager.recordStep();
+  project.camera.bombMove(node.geometryCenter);
 }
 
 function AIChatPanel({ project, winId }: { project: Project; winId: string }) {
@@ -198,8 +236,16 @@ function AIChatPanel({ project, winId }: { project: Project; winId: string }) {
           </div>
         ) : (
           <div className="flex flex-col gap-4">
-            {messages.map((message) => (
-              <MessageBubble key={message.id} message={message as any} components={markdownComponents} />
+            {messages.map((message, index) => (
+              <MessageBubble
+                key={message.id}
+                message={message as any}
+                components={markdownComponents}
+                project={project}
+                selectedCount={selectedCount}
+                isLast={index === messages.length - 1}
+                requesting={requesting}
+              />
             ))}
           </div>
         )}
@@ -271,9 +317,17 @@ function formatTokenCount(value: number) {
 function MessageBubble({
   message,
   components,
+  project,
+  selectedCount,
+  isLast,
+  requesting,
 }: {
   message: any;
   components?: Record<string, React.ComponentType<any>>;
+  project: Project;
+  selectedCount: number;
+  isLast: boolean;
+  requesting: boolean;
 }) {
   const isUser = message.role === "user";
   const parts = Array.isArray(message.parts) ? message.parts : [];
@@ -322,6 +376,14 @@ function MessageBubble({
           >
             <Markdown source={String(message.content ?? "")} components={components} />
           </div>
+        )}
+        {!isUser && selectedCount === 1 && parts.some((p: any) => p.type === "text") && (!isLast || !requesting) && (
+          <button
+            className="text-muted-foreground hover:text-foreground mt-1 flex cursor-pointer items-center self-end text-xs"
+            onClick={() => createAnswerNode(message, project)}
+          >
+            <Plus className="size-3.5" />
+          </button>
         )}
       </div>
       {isUser && (


### PR DESCRIPTION
## 功能

框选含图片的 Section → 在 AI 对话框提问 → AI 识别图片内容 → 点回复下方「+」按钮把答案落盘为 TextNode，并从选中节点拉一条连线指向它。

## 动机

让 AI 能"看见"画布上选中 Section 内的图片，并提供快捷动作把答案落盘成可追溯的 TextNode + 连线（类似 Tab 生长子节点的语义）。

## 实现

**图片识别工具 `recognize_image_by_uuid({ uuid, prompt })`**
- AI 调用时传入识别 prompt + 图片节点 uuid
- 工具内部用项目 AI 配置（`aiApiBaseUrl/aiApiKey/aiModel`）发起**独立的多模态调用**（仅 prompt + image，不携带主对话的系统提示词/历史，专注于图像识别）
- 返回图片的文字描述
- 多模态走 **user message**（标准 API，兼容 Gemini 2.5-flash 等视觉模型），不依赖实验性的多模态 tool result

**答案落盘「+」按钮（AIWindow）**
- 仅当**正好选中 1 个节点**且**消息流式完成后**显示，避免误触/残缺答案
- 点击创建答案 TextNode（源节点右侧 100px）+ `connectConnectableEntity` 连线 + 入历史栈（可撤销）+ 镜头聚焦

**辅助**
- `imageNodeFinder.ts`：`findFirstImageInChildren` 纯函数（从 Section children 递归找首个图片节点）+ 4 个单元测试
- `imageUtils.tsx`：`blobToCompressedDataUrl`（Blob → 按 `maxPastedImageSize` 等比压缩 → data URL），含零尺寸 guard
- `AITools.tsx`：`addTool`/`createTools` 增强可选 `toModelOutput`（现有 17 个工具行为不变）

## 改动文件

- `app/src/core/service/dataManageService/aiEngine/AITools.tsx`
- `app/src/core/service/dataManageService/aiEngine/imageNodeFinder.ts`（新）
- `app/src/core/service/dataManageService/aiEngine/imageNodeFinder.test.ts`（新）
- `app/src/core/service/dataManageService/imageUtils.tsx`
- `app/src/sub/AIWindow.tsx`

## 测试

- `imageNodeFinder` 4 个单元测试通过（vitest）：直接命中 / 单层递归 / 多层嵌套 / 无图返回 undefined
- tsc 无新增错误
- 端到端手测：图片识别准确描述内容；落盘按钮单选+完成后显示，点击创建 TextNode+连线，可撤销

🤖 Generated with [Claude Code](https://claude.com/claude-code)