### PR TITLE
fix: AI 对话框 Enter 不误触发 Section 重命名 + 修复气泡文字对比度

### DIFF
--- a/app/src/components/ui/markdown.tsx
+++ b/app/src/components/ui/markdown.tsx
@@ -32,7 +32,13 @@ export default function Markdown({
   }, [source, components]);
 
   return (
-    <div className={cn(className, "prose prose-neutral dark:prose-invert cursor-text text-sm select-text")}>
+    <div
+      className={cn(
+        className,
+        "prose max-w-none cursor-text text-sm select-text",
+        "[--tw-prose-body:var(--card-foreground)] [--tw-prose-bold:var(--card-foreground)] [--tw-prose-bullets:var(--muted-foreground)] [--tw-prose-captions:var(--muted-foreground)] [--tw-prose-code:var(--card-foreground)] [--tw-prose-counters:var(--muted-foreground)] [--tw-prose-headings:var(--card-foreground)] [--tw-prose-hr:var(--border)] [--tw-prose-lead:var(--card-foreground)] [--tw-prose-links:var(--primary)] [--tw-prose-pre-bg:var(--muted)] [--tw-prose-pre-code:var(--card-foreground)] [--tw-prose-quote-borders:var(--border)] [--tw-prose-quotes:var(--muted-foreground)] [--tw-prose-td-borders:var(--border)] [--tw-prose-th-borders:var(--border)]",
+      )}
+    >
       {content}
     </div>
   );

--- a/app/src/sub/AIWindow.tsx
+++ b/app/src/sub/AIWindow.tsx
@@ -118,6 +118,7 @@ function AIChatPanel({ project, winId }: { project: Project; winId: string }) {
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
+      e.stopPropagation();
       handleUserSend();
     }
   }


### PR DESCRIPTION
## 修复的两个 Bug

### 1. AI 对话框按 Enter 误触发选中的 Section 重命名

**根因**

Controller 基类把 keydown 绑定到 `canvas.element`，但没有像 `KeyBindsUI` 那样检查焦点是否在输入框内。AI 对话框的 Textarea 按下 Enter 时，事件通过某种路径到达了 `ControllerSectionEdit.keydown`（例如 canvas 元素仍获得焦点时的事件冒泡），导致选中的 Section 被重命名。

**修复方案**

- `AIWindow.tsx`：`handleKeyDown` 增加 `e.stopPropagation()`，让 Textarea 的 Enter 事件自我封闭，不再向外冒泡。
- `ControllerClass.tsx`：在 `canvas.element` 的 keydown 监听器里增加焦点守卫——当 `document.activeElement` 是 `INPUT` / `TEXTAREA` / `contenteditable="true"` 时直接返回。
- `ControllerSectionEdit.tsx`：在 `keydown` 方法里同样增加焦点守卫，作为兜底防御。

这样即使 SubWindow 焦点管理或 React 事件合成出现边界情况，输入框内的 Enter 也不会误触画布操作。

### 2. AI 对话框气泡文字与背景色近似，看不清

**根因**

`Markdown.tsx` 使用固定配色 `prose prose-neutral dark:prose-invert`，但 project-graph 的主题切换不通过 `.dark` class，而是直接把 CSS 变量注入 `:root`。切换暗色主题后 `.dark` 类不存在，`prose-neutral` 仍按浅色文字渲染，导致深灰文字落在深色 `bg-card` 气泡上，对比度极差。

**修复方案**

显式把所有 prose 文字颜色变量映射到 shadcn 主题 CSS 变量（`--card-foreground`、`--primary`、`--muted-foreground`、`--border` 等），让气泡文字跟随主题，无论明暗主题都清晰可读。

## 改动文件

- `app/src/components/ui/markdown.tsx`
- `app/src/core/service/controlService/controller/ControllerClass.tsx`
- `app/src/core/service/controlService/controller/concrete/ControllerSectionEdit.tsx`
- `app/src/sub/AIWindow.tsx`

## 验证

- `cd app && pnpm exec tsc --noEmit` 无新增错误（仓库有 11 条预存无关错误）
- 本地运行 `pnpm dev` 测试：AI 对话框按 Enter 不再触发 Section 重命名；暗色主题下气泡文字对比度正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)